### PR TITLE
검색 버튼 롤백

### DIFF
--- a/app/src/main/java/com/example/afreecatvassignment/ui/searchrepository/SearchRepositoryActivity.kt
+++ b/app/src/main/java/com/example/afreecatvassignment/ui/searchrepository/SearchRepositoryActivity.kt
@@ -99,7 +99,7 @@ class SearchRepositoryActivity : AppCompatActivity() {
             val currentTime = System.currentTimeMillis()
             if (currentTime - lastTime >= PERIODMILLIS) {
                 lastTime = currentTime
-                viewModel.fetchRepositoryList()
+                viewModel.fetchRepositoryListNewKeyword(0L)
             }
         }
     }

--- a/app/src/main/java/com/example/afreecatvassignment/ui/searchrepository/SearchRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/afreecatvassignment/ui/searchrepository/SearchRepositoryViewModel.kt
@@ -34,7 +34,10 @@ class SearchRepositoryViewModel @Inject constructor(
     val noMoreData: SharedFlow<Unit> = _noMoreData
 
     private val _cantAccessNetwork = MutableSharedFlow<Unit>()
-    var cantAccessNetwork: SharedFlow<Unit> = _cantAccessNetwork
+    val cantAccessNetwork: SharedFlow<Unit> = _cantAccessNetwork
+
+    private val _searchEvent = MutableSharedFlow<Unit>()
+    val searchEvent: SharedFlow<Unit> = _searchEvent
 
     private val _repositoryList = MutableStateFlow<List<GitRepository>>(emptyList())
     val repositoryList: StateFlow<List<GitRepository>> = _repositoryList
@@ -49,6 +52,21 @@ class SearchRepositoryViewModel @Inject constructor(
                 GitRepository(item.fullName, item.owner.avatarUrl, item.language)
             }
         }
+
+    fun fetchRepositoryList() {
+        viewModelScope.launch {
+            _isSearch.value = true
+
+            if (keyword.value.isNotBlank()) {
+                when (val result = fetchRepositoryList(currentPage)) {
+                    null -> _cantAccessNetwork.emit(Unit)
+                    else -> _repositoryList.value = result
+                }
+            }
+
+            _isSearch.value = false
+        }
+    }
 
     fun fetchRepositoryListNewKeyword() {
         currentPage = 1
@@ -86,6 +104,12 @@ class SearchRepositoryViewModel @Inject constructor(
             }
             _isSearchingNextPage.value = false
             loadingFlag.set(false)
+        }
+    }
+
+    fun emitSearchEvent() {
+        viewModelScope.launch {
+            _searchEvent.emit(Unit)
         }
     }
 

--- a/app/src/main/java/com/example/afreecatvassignment/ui/searchrepository/SearchRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/afreecatvassignment/ui/searchrepository/SearchRepositoryViewModel.kt
@@ -77,17 +77,19 @@ class SearchRepositoryViewModel @Inject constructor(
                 return@launch
             }
             loadingFlag.set(true)
-            _isSearchingNextPage.value = true
 
-            when (val result = fetchRepositoryList(currentPage + 1)) {
-                null -> _cantAccessNetwork.emit(Unit)
-                isEmpty -> _noMoreData.emit(Unit)
-                else -> {
-                    _repositoryList.value += result
-                    currentPage++
+            if (keyword.value.isNotBlank()) {
+                _isSearchingNextPage.value = true
+                when (val result = fetchRepositoryList(currentPage + 1)) {
+                    null -> _cantAccessNetwork.emit(Unit)
+                    isEmpty -> _noMoreData.emit(Unit)
+                    else -> {
+                        _repositoryList.value += result
+                        currentPage++
+                    }
                 }
+                _isSearchingNextPage.value = false
             }
-            _isSearchingNextPage.value = false
             loadingFlag.set(false)
         }
     }

--- a/app/src/main/java/com/example/afreecatvassignment/ui/searchrepository/SearchRepositoryViewModel.kt
+++ b/app/src/main/java/com/example/afreecatvassignment/ui/searchrepository/SearchRepositoryViewModel.kt
@@ -53,27 +53,12 @@ class SearchRepositoryViewModel @Inject constructor(
             }
         }
 
-    fun fetchRepositoryList() {
-        viewModelScope.launch {
-            _isSearch.value = true
-
-            if (keyword.value.isNotBlank()) {
-                when (val result = fetchRepositoryList(currentPage)) {
-                    null -> _cantAccessNetwork.emit(Unit)
-                    else -> _repositoryList.value = result
-                }
-            }
-
-            _isSearch.value = false
-        }
-    }
-
-    fun fetchRepositoryListNewKeyword() {
+    fun fetchRepositoryListNewKeyword(debounceLimit: Long) {
         currentPage = 1
         searchDebounceJob.cancel()
         searchDebounceJob = viewModelScope.launch {
             _isSearch.value = true
-            delay(DEBOUNCE_LIMIT)
+            delay(debounceLimit)
 
             if (keyword.value.isNotBlank()) {
                 when (val result = fetchRepositoryList(currentPage)) {
@@ -111,9 +96,5 @@ class SearchRepositoryViewModel @Inject constructor(
         viewModelScope.launch {
             _searchEvent.emit(Unit)
         }
-    }
-
-    companion object {
-        private const val DEBOUNCE_LIMIT = 500L
     }
 }

--- a/app/src/main/res/layout/activity_search_repository.xml
+++ b/app/src/main/res/layout/activity_search_repository.xml
@@ -29,16 +29,17 @@
             <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/toolbar_searchRepository"
                 android:layout_width="match_parent"
-                android:layout_height="?actionBarSize">
+                android:layout_height="?actionBarSize"
+                app:menu="@menu/menu_search_repository">
 
                 <EditText
                     android:id="@+id/et_searchRepository_toolbar"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:autofillHints=""
-                    android:afterTextChanged="@{() -> viewModel.fetchRepositoryListNewKeyword()}"
-                    android:hint="@string/searchRepository_et_hint"
                     android:layout_marginHorizontal="8dp"
+                    android:afterTextChanged="@{() -> viewModel.fetchRepositoryListNewKeyword()}"
+                    android:autofillHints=""
+                    android:hint="@string/searchRepository_et_hint"
                     android:importantForAutofill="no"
                     android:inputType="textNoSuggestions"
                     android:text="@={viewModel.keyword}" />
@@ -53,10 +54,10 @@
             android:layout_height="wrap_content"
             android:text="@string/tv_emptyList"
             android:visibility="@{viewModel.isEmpty() ? View.VISIBLE : View.GONE}"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="@id/rv_searchRepository"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@id/rv_searchRepository"
-            app:layout_constraintBottom_toBottomOf="@id/rv_searchRepository" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/rv_searchRepository" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_searchRepository"
@@ -76,10 +77,10 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:visibility="@{viewModel.isSearch() ? View.VISIBLE : View.GONE}"
-            app:layout_constraintTop_toTopOf="@id/rv_searchRepository"
             app:layout_constraintBottom_toBottomOf="@id/rv_searchRepository"
+            app:layout_constraintEnd_toEndOf="@id/rv_searchRepository"
             app:layout_constraintStart_toStartOf="@id/rv_searchRepository"
-            app:layout_constraintEnd_toEndOf="@id/rv_searchRepository" />
+            app:layout_constraintTop_toTopOf="@id/rv_searchRepository" />
 
         <ProgressBar
             android:id="@+id/pb_searchRepository_nextPage"

--- a/app/src/main/res/layout/activity_search_repository.xml
+++ b/app/src/main/res/layout/activity_search_repository.xml
@@ -37,7 +37,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:layout_marginHorizontal="8dp"
-                    android:afterTextChanged="@{() -> viewModel.fetchRepositoryListNewKeyword()}"
+                    android:afterTextChanged="@{() -> viewModel.fetchRepositoryListNewKeyword(500L)}"
                     android:autofillHints=""
                     android:hint="@string/searchRepository_et_hint"
                     android:importantForAutofill="no"


### PR DESCRIPTION
## what is this pr
키워드 드바운스 처리로 검색 버튼의 필요성을 못 느껴 삭제했다가, 특수한 경우 필요할 수 있기 때문에 기능 롤백
네트워크 연결이 되어있지 않거나 불안정해 데이터를 받아오지 못했을 때, 검색어를 한번 더 검색할 수 있도록 함
Resolve: #20 

## Changes
툴바에 메뉴 검색 버튼 롤백
검색 버튼으로 검색할 시 디바운스 처리하지 않도록 수정
